### PR TITLE
Pass host orchestrator when creating abstract host

### DIFF
--- a/lib/cs-host.js
+++ b/lib/cs-host.js
@@ -6,8 +6,10 @@ const ContainershipApi = require('@containership/containership.api-bridge');
 
 class CSHost extends HostImplementation {
     constructor(core) {
+        const orchestrator = 'containership';
         const attrs = core.cluster.legiond.get_attributes();
-        super(core.options.mode, attrs.address.public, core.options['api-port']);
+
+        super(orchestrator, core.options.mode, attrs.address.public, core.options['api-port']);
         this.privateIP = attrs.address.private;
         this.core = core;
     }

--- a/lib/k8s-host.js
+++ b/lib/k8s-host.js
@@ -6,7 +6,9 @@ const KubernetesApi = require('@containership/containership.k8s.api-bridge');
 
 class K8SHost extends HostImplementation {
     constructor(mode, leaderIP, apiPort, organizationId, clusterId) {
-        super(mode, leaderIP, apiPort);
+        const orchestrator = 'kubernetes';
+
+        super(orchestrator, mode, leaderIP, apiPort);
         this.organizationId = organizationId;
         this.clusterId = clusterId;
         this.attrs = {};


### PR DESCRIPTION
Sets newly required orchestrator when extending `HostImplementation`

Depends on containership/containership.abstraction.host#1