### PR TITLE
If cluster_id explicitly passed

### DIFF
--- a/lib/k8s-host.js
+++ b/lib/k8s-host.js
@@ -5,14 +5,17 @@ const async = require('async');
 const constants = require('containership.core.constants');
 const HostImplementation = require('@containership/containership.abstraction.host');
 const KubernetesApi = require('@containership/containership.k8s.api-bridge');
-const uuid = require('node-uuid');
 
 const CONSTRAINT_ENFORCEMENT_INTERVAL = (60 * 1000);
 
 class K8SHost extends HostImplementation {
     constructor(host_id, cluster_id, mode, api_ip, api_port, k8s_api_ip, k8s_api_port) {
-        const orchestrator = 'kubernetes';
+        // TODO - Update to support opensource installs
+        if(!cluster_id) {
+            throw new Error('You must pass cluster_id when instantiating a K8S Host!');
+        }
 
+        const orchestrator = 'kubernetes';
         super(orchestrator, host_id, mode, api_ip, api_port);
 
         this.api_ip = this.api_ip || 'localhost';
@@ -24,65 +27,20 @@ class K8SHost extends HostImplementation {
 
         this.api = new KubernetesApi(k8s_api_ip, k8s_api_port);
 
+        // leaders that join cluster should update cluster id
+        // TODO: update for multi-master support
         if(this.getOperatingMode() === 'leader') {
             setInterval(() => {
                 this.api.enforceAllConstraints();
             }, CONSTRAINT_ENFORCEMENT_INTERVAL);
+
+            this._setDistributedClusterId(cluster_id);
         }
 
-        // get cluster id from distributed state
-        this.api.getDistributedKey(constants.myriad.CLUSTER_ID, (err, distributed_cluster_id) => {
-            if(!err && distributed_cluster_id) {
-                this.setClusterId(distributed_cluster_id);
-                this.is_ready = true;
-                this._triggerReadyQueue();
-            }
-
-            let error_connecting = false;
-
-            // listen for changes to cluster id from the leader and set interally accordingly
-            const cluster_id_listener = this.api.subscribeDistributedKey(constants.myriad.CLUSTER_ID);
-            cluster_id_listener.on('message', (new_cluster_id) => {
-                if(error_connecting) {
-                    error_connecting = false;
-                }
-
-                console.info(`Setting the cluster id: ${new_cluster_id}`);
-                this.setClusterId(new_cluster_id);
-                this.is_ready = true;
-                this._triggerReadyQueue();
-            });
-
-            cluster_id_listener.on('error', (err) => {
-                if(!error_connecting) {
-                    console.error(`Error setting cluster_id: ${err}`);
-                    error_connecting = true;
-                }
-            });
-
-            // leaders that join cluster should update cluster id
-            // TODO: update for multi-master support
-            if(this.getOperatingMode() === 'leader') {
-                // set a default cluster id if one does not exist
-                if(!cluster_id) {
-                    cluster_id = uuid.v4();
-                }
-
-                return async.retry({
-                    times: 8,
-                    interval: function(attempt) {
-                        // retry intervals (500, 1000, 2000, 4000, 8000, 16000, 32000, 64000, ... milliseconds)
-                        return 250 * Math.pow(2, attempt);
-                    }
-                }, (cb) => {
-                    return this.api.setDistributedKey(constants.myriad.CLUSTER_ID, cluster_id, cb);
-                }, (err) => {
-                    if(err) {
-                        return console.error('Failed to set cluster id distributed key for the cluster', err);
-                    }
-                });
-            }
-        });
+        // cluster_id explicitly passed in
+        this.setClusterId(cluster_id);
+        this.is_ready = true;
+        this._triggerReadyQueue();
     }
 
     getApi() {
@@ -95,6 +53,31 @@ class K8SHost extends HostImplementation {
 
     setAttributes(attrs) {
         this.attrs = _.merge(this.attrs, attrs);
+    }
+
+    _setDistributedClusterId(cluster_id) {
+        return async.retry({
+            times: 8,
+            interval: function(attempt) {
+                // retry intervals (500, 1000, 2000, 4000, 8000, 16000, 32000, 64000, ... milliseconds)
+                return 250 * Math.pow(2, attempt);
+            }
+        }, (cb) => {
+            return this.api.setDistributedKey(constants.myriad.CLUSTER_ID, cluster_id, (err) => {
+                if(err) {
+                    console.warn('Failed to set distributed key: ', err);
+                    return cb(err);
+                }
+
+                return cb();
+            });
+        }, (err) => {
+            if(err) {
+                return console.error('Async retry failed to set the cluster_id: ', err);
+            }
+
+            return console.info(`Successfully set the cluster_id distributed key: ${cluster_id}`);
+        });
     }
 
     once(event, callback) {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "@containership/containership.k8s.api-bridge": "git://github.com/containership/containership.k8s.api-bridge.git",
     "async": "^2.5.0",
     "containership.core.constants": "^0.3.0",
-    "lodash": "^4.17.4",
-    "node-uuid": "^1.4.8"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "eslint": "^3.19.0"


### PR DESCRIPTION
@normanjoyner @jeremykross 

Temporarily simplifying to always expect cluster ID passed into constructor